### PR TITLE
Mf 163 health checks

### DIFF
--- a/src/SFA.DAS.Reservations.Infrastructure/Api/ApiClient.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/Api/ApiClient.cs
@@ -52,6 +52,22 @@ namespace SFA.DAS.Reservations.Infrastructure.Api
             }
         }
 
+        public async Task<string> Ping()
+        {
+            var pingUrl = _apiOptions.Value.Url;
+
+            pingUrl += pingUrl.EndsWith("/") ? "ping" : "/ping";
+
+            using (var client = new HttpClient())//not unit testable using directly
+            {
+                var response = await client.GetAsync(pingUrl).ConfigureAwait(false);
+
+                response.EnsureSuccessStatusCode();
+                var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return result;
+            }
+        }
+
         private async Task<string> GetAccessTokenAsync()
         {
             var clientCredential = new ClientCredential(_apiOptions.Value.Id, _apiOptions.Value.Secret);

--- a/src/SFA.DAS.Reservations.Infrastructure/Api/IApiClient.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/Api/IApiClient.cs
@@ -7,5 +7,6 @@ namespace SFA.DAS.Reservations.Infrastructure.Api
     {
         Task<TResponse> Get<TResponse>(IGetApiRequest request);
         Task<TResponse> Create<TResponse>(IPostApiRequest request);
+        Task<string> Ping();
     }
 }

--- a/src/SFA.DAS.Reservations.Infrastructure/Extensions/TimeSpanExtensions.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace SFA.DAS.Reservations.Infrastructure.Extensions
+{
+    public static class TimeSpanExtensions
+    {
+        public static string ToHumanReadableString(this TimeSpan timeSpan)
+        {
+            if (timeSpan.TotalSeconds <= 1)
+            {
+                return $"{timeSpan:fff} ms";
+            }
+            
+            if (timeSpan.TotalMinutes <= 1)
+            {
+                return $"{timeSpan:%s} seconds";
+            }
+
+            if (timeSpan.TotalHours <= 1)
+            {
+                return $"{timeSpan:%m} minutes";
+            }
+
+            if (timeSpan.TotalDays <= 1)
+            {
+                return $"{timeSpan:%h} hours";
+            }
+
+            return $"{timeSpan:%d} days";
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/ApiHealthCheck.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/ApiHealthCheck.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.ProviderRelationships.Api.Client.Http;
+using SFA.DAS.Reservations.Infrastructure.Api;
+using SFA.DAS.Reservations.Infrastructure.Extensions;
+
+namespace SFA.DAS.Reservations.Infrastructure.HealthCheck
+{
+    public class ApiHealthCheck : IHealthCheck
+    {
+        private const string HealthCheckResultDescription = "Reservation Api check";
+        
+        private readonly IApiClient _apiClient;
+        private readonly ILogger<ApiHealthCheck> _logger;
+
+        public ApiHealthCheck(IApiClient apiClient, ILogger<ApiHealthCheck> logger)
+        {
+            _apiClient = apiClient;
+            _logger = logger;
+        }
+        
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Pinging Reservation API");
+            
+            try
+            {
+                var timer = Stopwatch.StartNew();
+                await _apiClient.Ping();
+                timer.Stop();
+
+                var durationString = timer.Elapsed.ToHumanReadableString();
+                
+                _logger.LogInformation($"Reservation API ping successful and took {durationString}");
+                
+                return HealthCheckResult.Healthy(HealthCheckResultDescription, 
+                    new Dictionary<string, object>{{"Duration", durationString}});
+            }
+            catch (RestHttpClientException e)
+            {
+                _logger.LogWarning($"Reservation API ping failed : [Code: {e.StatusCode}] - {e.ReasonPhrase}");
+                return HealthCheckResult.Unhealthy(HealthCheckResultDescription, e);
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/HealthCheckResponseWriter.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/HealthCheckResponseWriter.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SFA.DAS.Reservations.Infrastructure.HealthCheck
+{
+    public static class HealthCheckResponseWriter
+    {
+        public static Task WriteJsonResponse(HttpContext httpContext, HealthReport result)
+        {
+            httpContext.Response.ContentType = "application/json";
+
+            var json = new JObject(
+                new JProperty("status", result.Status.ToString()),
+                new JProperty("results", new JObject(result.Entries.Select(pair =>
+                    new JProperty(pair.Key, new JObject(
+                        new JProperty("status", pair.Value.Status.ToString()),
+                        new JProperty("description", pair.Value.Description),
+                        new JProperty("data", new JObject(pair.Value.Data.Select(
+                            p => new JProperty(p.Key, p.Value))))))))));
+            return httpContext.Response.WriteAsync(
+                json.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Web/SFA.DAS.Reservations.Web.csproj
+++ b/src/SFA.DAS.Reservations.Web/SFA.DAS.Reservations.Web.csproj
@@ -17,9 +17,12 @@
     <PackageReference Include="mediatr.extensions.microsoft.dependencyinjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="microsoft.aspnetcore.mvc.viewfeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />

--- a/src/SFA.DAS.Reservations.Web/StartupConfig/HstsStartup.cs
+++ b/src/SFA.DAS.Reservations.Web/StartupConfig/HstsStartup.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using SFA.DAS.Reservations.Infrastructure.HealthCheck;
+
+namespace SFA.DAS.Reservations.Web.StartupConfig
+{
+    public static class HstsStartup
+    {
+        public static IApplicationBuilder UseDasHsts(this IApplicationBuilder app)
+        {
+            var hostingEnvironment = app.ApplicationServices.GetService<IHostingEnvironment>();
+            
+            if (!hostingEnvironment.IsDevelopment())
+            {
+                app.UseHsts();
+            }
+
+            return app;
+        }
+        
+        public static IApplicationBuilder UseHealthChecks(this IApplicationBuilder app)
+        {
+            app.UseHealthChecks("/health", new HealthCheckOptions
+            {
+                ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse
+            });
+            
+            app.UseHealthChecks("/ping", new HealthCheckOptions
+            {
+                Predicate = (_) => false
+            });
+
+            return app;
+        }
+    }
+}


### PR DESCRIPTION
Adds health check support for website. To test just add '/ping' to base url to test ping (is website up and running) and '/health' to check if website is healthy. The health check will return the API to not be available (404) until it has been updated with the health check code itself.