### PR TITLE
MF-177 Change for manage for providers

### DIFF
--- a/src/SFA.DAS.Reservations.Web.UnitTests/Reservations/WhenCallingGetManage.cs
+++ b/src/SFA.DAS.Reservations.Web.UnitTests/Reservations/WhenCallingGetManage.cs
@@ -98,7 +98,7 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Reservations
             var viewModel = result.Model as ManageViewModel;
             viewModel.Should().NotBeNull();
             viewModel.Reservations.Should().BeEquivalentTo(expectedReservations,
-                options => options.ExcludingMissingMembers());
+                options => options.ExcludingMissingMembers().ExcludingFields().Excluding(c=>c.ApprenticeUrl));
         }
 
         [Test, MoqAutoData]
@@ -166,10 +166,11 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Reservations
         }
 
         [Test, MoqAutoData]
-        public async Task UkPrnWillBePopulatedFromRouteModelIfNotPopulatedInReservation(
+        public async Task UkPrn_Will_Be_Populated_From_RouteModel_For_Each_Reservation(
              ReservationsRouteModel routeModel,
             GetTrustedEmployersResponse getTrustedEmployersResponse,
             Reservation reservation,
+             Reservation reservationTwo,
             string hashedId,
             [Frozen] ReservationsWebConfiguration config,
             [Frozen] Mock<IEncodingService> mockEncodingService,
@@ -187,7 +188,7 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Reservations
                 .Setup(mediator => mediator.Send(It.IsAny<GetReservationsQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GetReservationsResult
                 {
-                    Reservations = new []{reservation}
+                    Reservations = new []{reservation, reservationTwo }
                 });
 
             mockEncodingService
@@ -199,7 +200,7 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Reservations
             var viewModel = result?.Model as ManageViewModel;
             viewModel.Should().NotBeNull();
 
-            Assert.IsTrue(viewModel.Reservations.First().ApprenticeUrl.StartsWith($"{config.ApprenticeUrl}/{routeModel.UkPrn}/"));
+            Assert.IsTrue(viewModel.Reservations.All(c=>c.ApprenticeUrl.StartsWith($"{config.ApprenticeUrl}/{routeModel.UkPrn}/")));
 
         }
 

--- a/src/SFA.DAS.Reservations.Web/Controllers/ReservationsController.cs
+++ b/src/SFA.DAS.Reservations.Web/Controllers/ReservationsController.cs
@@ -320,7 +320,7 @@ namespace SFA.DAS.Reservations.Web.Controllers
 
                 foreach (var reservation in reservationsResult.Reservations)
                 {
-                    if (!reservation.ProviderId.HasValue || reservation.ProviderId == 0)
+                    if (routeModel.UkPrn.HasValue)
                     {
                         reservation.ProviderId = routeModel.UkPrn;
                     }


### PR DESCRIPTION
Manage for providers will now allow reservations made by a different
provider that has the same legal entity permissions to add an apprentice