### PR TITLE
MF-481 - Remove AccountId and AccountLegalEntityId from url

### DIFF
--- a/src/SFA.DAS.Reservations.Web.AcceptanceTests/Infrastructure/TestDataValues.cs
+++ b/src/SFA.DAS.Reservations.Web.AcceptanceTests/Infrastructure/TestDataValues.cs
@@ -4,11 +4,13 @@
     {
         public const long NonLevyAccountId = 1;
         public const long NonLevyAccountLegalEntityId = 123;
+        public const string NonLevyPublicHashedAccountId = "FEA456";
         public const string NonLevyHashedAccountId = "ABC123";
         public const string NonLevyHashedAccountLegalEntityId = "5UM71N6";
 
         public const long LevyAccountId = 2;
         public const long LevyAccountLegalEntityId = 456;
+        public const string LevyPublicHashedAccountId = "AEF456";
         public const string LevyHashedAccountId = "DEF456";
         public const string LevyHashedAccountLegalEntityId = "N077H15";
 

--- a/src/SFA.DAS.Reservations.Web.AcceptanceTests/Infrastructure/TestServiceCollectionExtension.cs
+++ b/src/SFA.DAS.Reservations.Web.AcceptanceTests/Infrastructure/TestServiceCollectionExtension.cs
@@ -26,11 +26,13 @@ namespace SFA.DAS.Reservations.Web.AcceptanceTests.Infrastructure
             encodingService.Setup(x => x.Decode(TestDataValues.NonLevyHashedAccountId,It.IsAny<EncodingType>())).Returns(TestDataValues.NonLevyAccountId);
             var nonLevyOutVariable = TestDataValues.NonLevyAccountId;
             encodingService.Setup(x => x.TryDecode(TestDataValues.NonLevyHashedAccountId,It.IsAny<EncodingType>(), out nonLevyOutVariable)).Returns(true);
+            encodingService.Setup(x => x.Decode(TestDataValues.NonLevyPublicHashedAccountId,EncodingType.PublicAccountId)).Returns(TestDataValues.NonLevyAccountId);
             encodingService.Setup(x => x.Encode(TestDataValues.NonLevyAccountId,It.IsAny<EncodingType>())).Returns(TestDataValues.NonLevyHashedAccountId);
             encodingService.Setup(x => x.Encode(TestDataValues.NonLevyAccountLegalEntityId, EncodingType.PublicAccountLegalEntityId)).Returns(TestDataValues.NonLevyHashedAccountLegalEntityId);
             encodingService.Setup(x => x.Decode(TestDataValues.NonLevyHashedAccountLegalEntityId, EncodingType.PublicAccountLegalEntityId)).Returns(TestDataValues.NonLevyAccountLegalEntityId);
 
             var levyOutVariable = TestDataValues.LevyAccountId;
+            encodingService.Setup(x => x.Decode(TestDataValues.LevyPublicHashedAccountId,EncodingType.PublicAccountId)).Returns(TestDataValues.LevyAccountId);
             encodingService.Setup(x => x.TryDecode(TestDataValues.LevyHashedAccountId,It.IsAny<EncodingType>(), out levyOutVariable)).Returns(true);
             encodingService.Setup(x => x.Decode(TestDataValues.LevyHashedAccountId,It.IsAny<EncodingType>())).Returns(TestDataValues.LevyAccountId);
             encodingService.Setup(x => x.Encode(TestDataValues.LevyAccountId,It.IsAny<EncodingType>())).Returns(TestDataValues.LevyHashedAccountId);

--- a/src/SFA.DAS.Reservations.Web.AcceptanceTests/Steps/Provider/ProviderCreateReservationSteps.cs
+++ b/src/SFA.DAS.Reservations.Web.AcceptanceTests/Steps/Provider/ProviderCreateReservationSteps.cs
@@ -35,8 +35,7 @@ namespace SFA.DAS.Reservations.Web.AcceptanceTests.Steps.Provider
             var confirmEmployerViewModel = new ConfirmEmployerViewModel
             {
                 Confirm = true,
-                AccountId = TestData.AccountLegalEntity.AccountId,
-                AccountLegalEntityId = TestData.AccountLegalEntity.AccountLegalEntityId,
+                AccountPublicHashedId = TestData.AccountLegalEntity.AccountPublicHashedId,
                 AccountLegalEntityName = TestData.AccountLegalEntity.AccountLegalEntityName,
                 AccountLegalEntityPublicHashedId = TestData.AccountLegalEntity.AccountLegalEntityPublicHashedId,
                 UkPrn = TestData.ReservationRouteModel.UkPrn.Value

--- a/src/SFA.DAS.Reservations.Web.AcceptanceTests/Steps/StepsBase.cs
+++ b/src/SFA.DAS.Reservations.Web.AcceptanceTests/Steps/StepsBase.cs
@@ -129,6 +129,7 @@ namespace SFA.DAS.Reservations.Web.AcceptanceTests.Steps
                 AccountLegalEntityId = TestDataValues.NonLevyAccountLegalEntityId,
                 AccountLegalEntityPublicHashedId = TestDataValues.NonLevyHashedAccountLegalEntityId,
                 AccountLegalEntityName = "Test Legal Entity",
+                AccountPublicHashedId = TestDataValues.NonLevyPublicHashedAccountId,
                 AgreementSigned = true,
                 IsLevy = false,
                 LegalEntityId = 1,
@@ -160,7 +161,7 @@ namespace SFA.DAS.Reservations.Web.AcceptanceTests.Steps
                 AccountId = TestDataValues.LevyAccountId,
                 AccountLegalEntityId = TestDataValues.LevyAccountLegalEntityId,
                 AccountLegalEntityPublicHashedId = TestDataValues.LevyHashedAccountLegalEntityId,
-                
+                AccountPublicHashedId = TestDataValues.LevyPublicHashedAccountId,
                 AccountLegalEntityName = "Test Legal Entity",
                 AgreementSigned = true,
                 IsLevy = true,
@@ -190,6 +191,7 @@ namespace SFA.DAS.Reservations.Web.AcceptanceTests.Steps
             TestData.AccountLegalEntity = new AccountLegalEntity
             {
                 AccountId = TestDataValues.NonLevyAccountId,
+                AccountPublicHashedId = TestDataValues.NonLevyPublicHashedAccountId,
                 AccountLegalEntityId = TestDataValues.NonLevyAccountLegalEntityId,
                 AccountLegalEntityPublicHashedId = TestDataValues.NonLevyHashedAccountLegalEntityId,
                 AccountLegalEntityName = "Test Legal Entity",

--- a/src/SFA.DAS.Reservations.Web.UnitTests/Providers/WhenViewingAnEmployerToConfirm.cs
+++ b/src/SFA.DAS.Reservations.Web.UnitTests/Providers/WhenViewingAnEmployerToConfirm.cs
@@ -19,9 +19,7 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Providers
     {
         
         [Test, MoqAutoData]
-        public async Task Then_If_There_The_ViewModel_Is_Passed_To_The_View_With_Encoded_Ids(
-            string hashedAccountId,
-            long accountId,
+        public async Task Then_The_ViewModel_Is_Passed_To_The_View(
             [Frozen] Mock<IMediator> mediator,
             ProviderReservationsController controller,
             ConfirmEmployerViewModel viewModel)

--- a/src/SFA.DAS.Reservations.Web/Controllers/ProviderReservationsController.cs
+++ b/src/SFA.DAS.Reservations.Web/Controllers/ProviderReservationsController.cs
@@ -122,8 +122,7 @@ namespace SFA.DAS.Reservations.Web.Controllers
                 });
 
                 viewModel.AccountLegalEntityName = result.AccountLegalEntityName;
-                viewModel.AccountId = result.AccountId;
-                viewModel.AccountLegalEntityId = result.AccountLegalEntityId;
+                viewModel.AccountPublicHashedId = _encodingService.Encode(result.AccountId, EncodingType.AccountId);
                 viewModel.AccountLegalEntityPublicHashedId = result.AccountLegalEntityPublicHashedId;
                 viewModel.AccountName = result.AccountName;
                 return View(viewModel);
@@ -159,8 +158,8 @@ namespace SFA.DAS.Reservations.Web.Controllers
                 await _mediator.Send(new CacheReservationEmployerCommand
                 {
                     Id = reservationId,
-                    AccountId = viewModel.AccountId,
-                    AccountLegalEntityId = viewModel.AccountLegalEntityId,
+                    AccountId = _encodingService.Decode(viewModel.AccountPublicHashedId, EncodingType.PublicAccountId),
+                    AccountLegalEntityId = _encodingService.Decode(viewModel.AccountLegalEntityPublicHashedId, EncodingType.PublicAccountLegalEntityId),
                     AccountLegalEntityName = viewModel.AccountLegalEntityName,
                     AccountLegalEntityPublicHashedId = viewModel.AccountLegalEntityPublicHashedId,
                     UkPrn = viewModel.UkPrn,

--- a/src/SFA.DAS.Reservations.Web/Models/ConfirmEmployerViewModel.cs
+++ b/src/SFA.DAS.Reservations.Web/Models/ConfirmEmployerViewModel.cs
@@ -5,10 +5,8 @@ namespace SFA.DAS.Reservations.Web.Models
     public class ConfirmEmployerViewModel
     {   
         public uint UkPrn { get; set; }
-        public long AccountId { get; set; }
         public string AccountPublicHashedId { get; set; }
         public string AccountName { get; set; }
-        public long AccountLegalEntityId { get; set; }
         public string AccountLegalEntityPublicHashedId { get; set; }
         public string AccountLegalEntityName { get; set; }
 

--- a/src/SFA.DAS.Reservations.Web/Views/ProviderReservations/ChooseEmployer.cshtml
+++ b/src/SFA.DAS.Reservations.Web/Views/ProviderReservations/ChooseEmployer.cshtml
@@ -41,10 +41,8 @@
                         var viewModel = new ConfirmEmployerViewModel
                         {
                             UkPrn = ukPrn,
-                            AccountId = employer.AccountId,
                             AccountPublicHashedId = employer.AccountPublicHashedId,
                             AccountName = employer.AccountName,
-                            AccountLegalEntityId = employer.AccountLegalEntityId,
                             AccountLegalEntityPublicHashedId = employer.AccountLegalEntityPublicHashedId,
                             AccountLegalEntityName = employer.AccountLegalEntityName
                         };

--- a/src/SFA.DAS.Reservations.Web/Views/ProviderReservations/ConfirmEmployer.cshtml
+++ b/src/SFA.DAS.Reservations.Web/Views/ProviderReservations/ConfirmEmployer.cshtml
@@ -29,12 +29,11 @@
 
             <form asp-route="@RouteNames.ProviderConfirmEmployer" method="POST">
 
+                @Html.HiddenFor(model => model.AccountPublicHashedId)
                 @Html.HiddenFor(model => model.AccountLegalEntityName)
-                @Html.HiddenFor(model => model.AccountLegalEntityId)
                 @Html.HiddenFor(model => model.AccountLegalEntityPublicHashedId)
                 @Html.HiddenFor(model => model.AccountName)
-                @Html.HiddenFor(model => model.AccountId)
-
+                
                 <div class="govuk-form-group @(ViewData.ModelState.IsValid ? "":"govuk-form-group--error")">
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">


### PR DESCRIPTION
Removed the AccountId and AccountLegalEntityId from the url when going through the provider journey and selecting an employer