### PR TITLE
Create shut out page for Provider Reservations who aren't allowed access to PAS

### DIFF
--- a/src/SFA.DAS.Reservations.Domain.UnitTests/ReservationsApi/WhenBuildingGetProviderAccountRequest.cs
+++ b/src/SFA.DAS.Reservations.Domain.UnitTests/ReservationsApi/WhenBuildingGetProviderAccountRequest.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture.NUnit3;
+using NUnit.Framework;
+using SFA.DAS.Reservations.Domain.Providers.Api;
+using FluentAssertions;
+
+namespace SFA.DAS.Reservations.Domain.UnitTests.ReservationsApi
+{
+    public class WhenBuildingGetProviderAccountRequest
+    {
+        [Test, AutoData]
+        public void Then_The_Url_Is_Correctly_Constructed(string baseUrl, int ukprn)
+        {
+            var actual = new GetProviderStatusDetails(baseUrl, ukprn);
+
+            actual.GetUrl.Should().Be($"provideraccounts/{ukprn}");
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Domain.UnitTests/ReservationsApi/WhenBuildingGetProviderAccountRequest.cs
+++ b/src/SFA.DAS.Reservations.Domain.UnitTests/ReservationsApi/WhenBuildingGetProviderAccountRequest.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.Reservations.Domain.UnitTests.ReservationsApi
         {
             var actual = new GetProviderStatusDetails(baseUrl, ukprn);
 
-            actual.GetUrl.Should().Be($"provideraccounts/{ukprn}");
+            actual.GetUrl.Should().Be($"{baseUrl}/provideraccounts/{ukprn}");
         }
     }
 }

--- a/src/SFA.DAS.Reservations.Domain/Interfaces/IReservationsOuterService.cs
+++ b/src/SFA.DAS.Reservations.Domain/Interfaces/IReservationsOuterService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using SFA.DAS.Reservations.Domain.Providers.Api;
 using SFA.DAS.Reservations.Domain.Reservations;
 
 namespace SFA.DAS.Reservations.Domain.Interfaces
@@ -6,5 +7,6 @@ namespace SFA.DAS.Reservations.Domain.Interfaces
     public interface IReservationsOuterService
     {
         Task<GetTransferValidityResponse> GetTransferValidity(long senderId, long receiverId, int? pledgeApplicationId=null);
+        Task<ProviderAccountResponse> GetProviderStatus(long ukprn);
     }
 }

--- a/src/SFA.DAS.Reservations.Domain/Providers/Api/GetProviderStatusDetails.cs
+++ b/src/SFA.DAS.Reservations.Domain/Providers/Api/GetProviderStatusDetails.cs
@@ -6,12 +6,12 @@ namespace SFA.DAS.Reservations.Domain.Providers.Api
     {
         private readonly long _ukprn;
         public string BaseUrl { get; }
-        public string GetUrl => $"{BaseUrl}api/provideraccounts/{_ukprn}";
+        public string GetUrl => $"{BaseUrl}provideraccounts/{_ukprn}";
 
         public GetProviderStatusDetails(string baseUrl, long ukprn)
         {
             _ukprn = ukprn;
-            BaseUrl = baseUrl;
+            BaseUrl = baseUrl.EndsWith('/') ? baseUrl : baseUrl + "/";
         }
     }
 }

--- a/src/SFA.DAS.Reservations.Domain/Providers/Api/GetProviderStatusDetails.cs
+++ b/src/SFA.DAS.Reservations.Domain/Providers/Api/GetProviderStatusDetails.cs
@@ -1,0 +1,17 @@
+﻿using SFA.DAS.Reservations.Domain.Interfaces;
+
+namespace SFA.DAS.Reservations.Domain.Providers.Api
+{
+    public class GetProviderStatusDetails : IGetApiRequest
+    {
+        private readonly long _ukprn;
+        public string BaseUrl { get; }
+        public string GetUrl => $"{BaseUrl}api/provideraccounts/{_ukprn}";
+
+        public GetProviderStatusDetails(string baseUrl, long ukprn)
+        {
+            _ukprn = ukprn;
+            BaseUrl = baseUrl;
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Domain/Providers/Api/ProviderAccountResponse.cs
+++ b/src/SFA.DAS.Reservations.Domain/Providers/Api/ProviderAccountResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SFA.DAS.Reservations.Domain.Providers.Api
+{
+    public class ProviderAccountResponse
+    {
+        [JsonPropertyName("canAccessService")]
+        public bool CanAccessService { get; set; }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure.UnitTests/Services/ReservationOuterService/WhenGettingProviderStatusTest.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure.UnitTests/Services/ReservationOuterService/WhenGettingProviderStatusTest.cs
@@ -1,0 +1,39 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Reservations.Domain.Providers.Api;
+using SFA.DAS.Reservations.Infrastructure.Api;
+using SFA.DAS.Reservations.Infrastructure.Configuration;
+using SFA.DAS.Testing.AutoFixture;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Reservations.Infrastructure.UnitTests.Services.ReservationOuterService
+{
+    public class WhenGettingProviderStatusTest
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Request_Is_Made_And_ProviderResponse_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IReservationsOuterApiClient> reservationsOuterApiClient,
+            [Frozen] Mock<IOptions<ReservationsOuterApiConfiguration>> outerApiConfiguration,
+            Infrastructure.Services.ReservationsOuterService service)
+        {
+            //Arrange
+            outerApiConfiguration.Object.Value.ApiBaseUrl = "https://tempuri.org";
+            var expectedRequest = new GetProviderStatusDetails(outerApiConfiguration.Object.Value.ApiBaseUrl, ukprn);
+            
+            reservationsOuterApiClient.Setup(x => x.Get<ProviderAccountResponse>(
+                    It.Is<GetProviderStatusDetails>(c => c.GetUrl.Equals(expectedRequest.GetUrl))))
+                .ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await service.GetProviderStatus(ukprn);
+
+            //Assert
+            actual.CanAccessService.Should().Be(apiResponse.CanAccessService);
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure/Services/ReservationsOuterService.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/Services/ReservationsOuterService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SFA.DAS.Reservations.Domain.Interfaces;
+using SFA.DAS.Reservations.Domain.Providers.Api;
 using SFA.DAS.Reservations.Domain.Reservations;
 using SFA.DAS.Reservations.Domain.Reservations.Api;
 using SFA.DAS.Reservations.Infrastructure.Api;
@@ -25,6 +26,11 @@ namespace SFA.DAS.Reservations.Infrastructure.Services
             var response = await _apiClient.Get<GetTransferValidityResponse>(request);
 
             return response;
+        }
+
+        public async Task<ProviderAccountResponse> GetProviderStatus(long ukprn)
+        {
+            return await _apiClient.Get<ProviderAccountResponse>(new GetProviderStatusDetails(_config.ApiBaseUrl, ukprn));
         }
     }
 }

--- a/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAllRolesRequirement.cs
@@ -1,0 +1,109 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Reservations.Domain.Providers.Api;
+using SFA.DAS.Reservations.Web.Infrastructure;
+using SFA.DAS.Testing.AutoFixture;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Reservations.Web.UnitTests.Infrastructure.TrainingProviderAllRolesRequirementHandlerTest
+{
+    public class WhenHandlingTrainingProviderAllRolesRequirement
+    {
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_No_Provider_Ukprn_Claim(
+        int ukprn,
+        TrainingProviderAllRolesRequirement providerRequirement,
+        TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim("NotProviderClaim", ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsFalse(context.HasSucceeded);
+            Assert.IsTrue(context.HasFailed);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_Non_Numeric_Provider_Ukprn_Claim(
+            string ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn);
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsFalse(context.HasSucceeded);
+            Assert.IsTrue(context.HasFailed);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Fails_If_Provider_Ukprn_Claim_Response_Is_False(
+            int ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            [Frozen] Mock<ITrainingProviderAuthorizationHandler> trainingProviderAuthorizationHandler,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var httpContextBase = new Mock<HttpContext>();
+            var httpResponse = new Mock<HttpResponse>();
+            httpContextBase.Setup(c => c.Response).Returns(httpResponse.Object);
+            var filterContext = new AuthorizationFilterContext(new ActionContext(httpContextBase.Object, new RouteData(), new ActionDescriptor()), new List<IFilterMetadata>());
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, filterContext);
+            var response = new ProviderAccountResponse { CanAccessService = false };
+            trainingProviderAuthorizationHandler.Setup(x => x.IsProviderAuthorized(context)).ReturnsAsync(response.CanAccessService);
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            context.HasSucceeded.Should().BeTrue();
+            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/401"))));
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Succeeds_If_Provider_Ukprn_Claim_Response_Is_True(
+            int ukprn,
+            TrainingProviderAllRolesRequirement providerRequirement,
+            [Frozen] Mock<ITrainingProviderAuthorizationHandler> trainingProviderAuthorizationHandler,
+            TrainingProviderAllRolesAuthorizationHandler authorizationHandler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { providerRequirement }, claimsPrinciple, null);
+            var response = new ProviderAccountResponse { CanAccessService = false };
+            trainingProviderAuthorizationHandler.Setup(x => x.IsProviderAuthorized(context)).ReturnsAsync(response.CanAccessService);
+
+
+            //Act
+            await authorizationHandler.HandleAsync(context);
+
+            //Assert
+            Assert.IsTrue(context.HasSucceeded);
+            Assert.IsFalse(context.HasFailed);
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAllRolesRequirement.cs
@@ -80,7 +80,7 @@ namespace SFA.DAS.Reservations.Web.UnitTests.Infrastructure.TrainingProviderAllR
 
             //Assert
             context.HasSucceeded.Should().BeTrue();
-            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/401"))));
+            httpResponse.Verify(x => x.Redirect(It.Is<string>(c => c.Contains("/error/403/invalid-status"))));
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAuthorization.cs
+++ b/src/SFA.DAS.Reservations.Web.UnitTests/Infrastructure/TrainingProviderAllRolesRequirementHandlerTest/WhenHandlingTrainingProviderAuthorization.cs
@@ -1,0 +1,97 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Reservations.Domain.Interfaces;
+using SFA.DAS.Reservations.Domain.Providers.Api;
+using SFA.DAS.Reservations.Web.Infrastructure;
+using SFA.DAS.Testing.AutoFixture;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Reservations.Web.UnitTests.Infrastructure.TrainingProviderAllRolesRequirementHandlerTest
+{
+    public class WhenHandlingTrainingProviderAuthorization
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderStatus_Is_Valid_And_True_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IReservationsOuterService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            apiResponse.CanAccessService = true;
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeTrue();
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderDetails_Is_InValid_And_False_Returned(
+            long ukprn,
+            ProviderAccountResponse apiResponse,
+            [Frozen] Mock<IReservationsOuterService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            apiResponse.CanAccessService = false;
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeFalse();
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_ProviderDetails_Is_Null_And_False_Returned(
+            long ukprn,
+            [Frozen] Mock<IReservationsOuterService> outerApiService,
+            [Frozen] Mock<IHttpContextAccessor> httpContextAccessor,
+            TrainingProviderAllRolesRequirement requirement,
+            TrainingProviderAuthorizationHandler handler)
+        {
+            //Arrange
+            var claim = new Claim(ProviderClaims.ProviderUkprn, ukprn.ToString());
+            var claimsPrinciple = new ClaimsPrincipal(new[] { new ClaimsIdentity(new[] { claim }) });
+            var context = new AuthorizationHandlerContext(new[] { requirement }, claimsPrinciple, null);
+            var responseMock = new FeatureCollection();
+            var httpContext = new DefaultHttpContext(responseMock);
+            httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+            outerApiService.Setup(x => x.GetProviderStatus(ukprn)).ReturnsAsync((ProviderAccountResponse)null!);
+
+            //Act
+            var actual = await handler.IsProviderAuthorized(context);
+
+            //Assert
+            actual.Should().BeFalse();
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Web/AppStart/AuthorizationService.cs
+++ b/src/SFA.DAS.Reservations.Web/AppStart/AuthorizationService.cs
@@ -34,6 +34,7 @@ namespace SFA.DAS.Reservations.Web.AppStart
                         policy.RequireClaim(ProviderClaims.ProviderUkprn);
                         policy.RequireAssertion(HasValidServiceClaim);
                         policy.Requirements.Add(new ProviderUkPrnRequirement());
+                        policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                     });
                 options.AddPolicy(
                     PolicyNames.HasProviderOrEmployerAccount, policy =>
@@ -42,6 +43,7 @@ namespace SFA.DAS.Reservations.Web.AppStart
                         ProviderOrEmployerAssertion(policy);
                         policy.Requirements.Add(new HasProviderOrEmployerAccountRequirement());
                         policy.Requirements.Add(new AccountActiveRequirement());
+                        policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                     });
                 options.AddPolicy(
                     PolicyNames.HasEmployerViewerUserRoleOrIsProvider
@@ -51,6 +53,7 @@ namespace SFA.DAS.Reservations.Web.AppStart
                         ProviderOrEmployerAssertion(policy);
                         policy.Requirements.Add(new HasEmployerViewerUserRoleOrIsProviderRequirement());
                         policy.Requirements.Add(new AccountActiveRequirement());
+                        policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                     });
                 options.AddPolicy(
                     PolicyNames.HasProviderGotViewerOrHigherRoleOrIsEmployer
@@ -60,6 +63,7 @@ namespace SFA.DAS.Reservations.Web.AppStart
                         ProviderOrEmployerAssertion(policy);
                         policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAV));
                         policy.Requirements.Add(new AccountActiveRequirement());
+                        policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                     });
                 options.AddPolicy(
                    PolicyNames.HasProviderGotContributorOrHigherRoleOrIsEmployer
@@ -69,6 +73,7 @@ namespace SFA.DAS.Reservations.Web.AppStart
                        ProviderOrEmployerAssertion(policy);
                        policy.Requirements.Add(new MinimumServiceClaimRequirement(ServiceClaim.DAC));
                        policy.Requirements.Add(new AccountActiveRequirement());
+                       policy.Requirements.Add(new TrainingProviderAllRolesRequirement());
                    });
             });
         }

--- a/src/SFA.DAS.Reservations.Web/AppStart/Configuration.cs
+++ b/src/SFA.DAS.Reservations.Web/AppStart/Configuration.cs
@@ -85,6 +85,9 @@ namespace SFA.DAS.Reservations.Web.AppStart
             
             services.AddTransient<ICustomClaims, EmployerAccountPostAuthenticationClaimsHandler>();
             services.AddTransient<IStubAuthenticationService, StubAuthenticationService>();
+
+            services.AddSingleton<ITrainingProviderAuthorizationHandler, TrainingProviderAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, TrainingProviderAllRolesAuthorizationHandler>();
         }
     }
 }

--- a/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesAuthorizationHandler.cs
+++ b/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesAuthorizationHandler.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using SFA.DAS.Reservations.Infrastructure.Configuration;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace SFA.DAS.Reservations.Web.Infrastructure
+{
+    public class TrainingProviderAllRolesAuthorizationHandler : AuthorizationHandler<TrainingProviderAllRolesRequirement>
+    {
+        private readonly ITrainingProviderAuthorizationHandler _handler;
+        private readonly IConfiguration _configuration;
+        private readonly ReservationsWebConfiguration _reservationsWebConfiguration;
+
+        public TrainingProviderAllRolesAuthorizationHandler(
+            ITrainingProviderAuthorizationHandler handler,
+            IConfiguration configuration,
+            IOptions<ReservationsWebConfiguration> reservationsWebConfiguration)
+        {
+            _handler = handler;
+            _reservationsWebConfiguration = reservationsWebConfiguration.Value;
+            _configuration = configuration;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, TrainingProviderAllRolesRequirement requirement)
+        {
+            HttpContext currentContext;
+            switch (context.Resource)
+            {
+                case HttpContext resource:
+                    currentContext = resource;
+                    break;
+                case AuthorizationFilterContext authorizationFilterContext:
+                    currentContext = authorizationFilterContext.HttpContext;
+                    break;
+                default:
+                    currentContext = null;
+                    break;
+            }
+
+            if (!context.User.HasClaim(c => c.Type.Equals(ProviderClaims.ProviderUkprn)))
+            {
+                context.Fail();
+                return;
+            }
+
+            var claimValue = context.User.FindFirst(c => c.Type.Equals(ProviderClaims.ProviderUkprn)).Value;
+
+            if (!int.TryParse(claimValue, out var ukprn))
+            {
+                context.Fail();
+                return;
+            }
+
+            var isStubProviderValidationEnabled = GetUseStubProviderValidationSetting();
+
+            // check if the stub is activated to by-pass the validation. Mostly used for local development purpose.
+            // logic to check if the provider is authorized if not redirect the user to PAS 401 un-authorized page.
+            if (!isStubProviderValidationEnabled && !(await _handler.IsProviderAuthorized(context)))
+            {
+                currentContext?.Response.Redirect($"{_reservationsWebConfiguration.DashboardUrl}/error/401");
+            }
+
+            context.Succeed(requirement);
+        }
+
+        private bool GetUseStubProviderValidationSetting()
+        {
+            var value = _configuration.GetSection("UseStubProviderValidation").Value;
+
+            return value != null && bool.TryParse(value, out var result) && result;
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesAuthorizationHandler.cs
+++ b/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesAuthorizationHandler.cs
@@ -60,7 +60,7 @@ namespace SFA.DAS.Reservations.Web.Infrastructure
             // logic to check if the provider is authorized if not redirect the user to PAS 401 un-authorized page.
             if (!isStubProviderValidationEnabled && !(await _handler.IsProviderAuthorized(context)))
             {
-                currentContext?.Response.Redirect($"{_reservationsWebConfiguration.DashboardUrl}/error/401");
+                currentContext?.Response.Redirect($"{_reservationsWebConfiguration.DashboardUrl}/error/403/invalid-status");
             }
 
             context.Succeed(requirement);

--- a/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesRequirement.cs
+++ b/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAllRolesRequirement.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace SFA.DAS.Reservations.Web.Infrastructure
+{
+    public class TrainingProviderAllRolesRequirement : IAuthorizationRequirement { }
+}

--- a/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAuthorizationHandler.cs
+++ b/src/SFA.DAS.Reservations.Web/Infrastructure/TrainingProviderAuthorizationHandler.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using SFA.DAS.Reservations.Domain.Interfaces;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Reservations.Web.Infrastructure
+{
+    /// <summary>
+    /// Interface to define contracts related to Training Provider Authorization Handlers.
+    /// </summary>
+    public interface ITrainingProviderAuthorizationHandler
+    {
+        /// <summary>
+        /// Contract to check is the logged in Provider is a valid Training Provider. 
+        /// </summary>
+        /// <param name="context">AuthorizationHandlerContext.</param>
+        /// <returns>boolean.</returns>
+        Task<bool> IsProviderAuthorized(AuthorizationHandlerContext context);
+    }
+
+    ///<inheritdoc cref="ITrainingProviderAuthorizationHandler"/>
+    public class TrainingProviderAuthorizationHandler : ITrainingProviderAuthorizationHandler
+    {
+        private readonly IReservationsOuterService _outerApiService;
+
+        public TrainingProviderAuthorizationHandler(
+            IReservationsOuterService outerApiService)
+        {
+            _outerApiService = outerApiService;
+        }
+
+        public async Task<bool> IsProviderAuthorized(AuthorizationHandlerContext context)
+        {
+            var ukprn = GetProviderId(context);
+
+            //if the ukprn is invalid return false.
+            if (ukprn <= 0) return false;
+
+            var providerStatusDetails = await _outerApiService.GetProviderStatus(ukprn);
+
+            // Condition to check if the Provider Details has permission to access Apprenticeship Services based on the property value "CanAccessApprenticeshipService" set to True.
+            return providerStatusDetails is { CanAccessService: true };
+        }
+
+        private static long GetProviderId(AuthorizationHandlerContext context)
+        {
+            return long.TryParse(context.User.FindFirst(c => c.Type.Equals(ProviderClaims.ProviderUkprn))?.Value, out var providerId)
+                ? providerId
+                : 0;
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Web/SFA.DAS.Reservations.Web.csproj
+++ b/src/SFA.DAS.Reservations.Web/SFA.DAS.Reservations.Web.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="6.0.97" />
-    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.61" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.63" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />

--- a/src/SFA.DAS.Reservations.Web/Startup.cs
+++ b/src/SFA.DAS.Reservations.Web/Startup.cs
@@ -25,6 +25,7 @@ using SFA.DAS.Reservations.Web.StartupConfig;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Logging;
 using SFA.DAS.DfESignIn.Auth.AppStart;
+using SFA.DAS.DfESignIn.Auth.Enums;
 
 namespace SFA.DAS.Reservations.Web
 {
@@ -138,7 +139,7 @@ namespace SFA.DAS.Reservations.Web
                         _configuration,
                         "SFA.DAS.ProviderApprenticeshipService",
                         typeof(CustomServiceRole),
-                        "ProviderRoATP",
+                        ClientName.ProviderRoatp,
                         "/signout",
                         "");    
                 }

--- a/src/SFA.DAS.Reservations.Web/appsettings.json
+++ b/src/SFA.DAS.Reservations.Web/appsettings.json
@@ -18,8 +18,9 @@
   },
   "AuthType": "provider",
   "UseStubs": true,
+  "UseStubProviderValidation": false,
   "ResourceEnvironmentName": "LOCAL",
-  "StubAuth" : "",
+  "StubAuth": "",
   "StubEmail": "some@email.test",
   "StubId": "some-id-test"
 }


### PR DESCRIPTION
Commit Details:
Added new Requirement to the Policy to check if the Provider is valid one. 
Condition 1: is the provider's profile a Main or Employer Profile. 
Condition 2: is the provider's status Active or On-boarding.

Story: https://skillsfundingagency.atlassian.net/browse/FAI-948